### PR TITLE
Byte-padding if size of document is odd

### DIFF
--- a/pdf2dicom.py
+++ b/pdf2dicom.py
@@ -27,7 +27,11 @@ def generate_dicom_from_pdf(pdf_file):
     ds.SOPClassUID = '1.2.840.10008.5.1.4.1.1.104.1'
 
     with open(pdf_file, 'rb') as f:
-        ds.EncapsulatedDocument = f.read()
+        f_read = f.read()
+        ValueLength = len(f_read)
+        if ValueLength % 2 != 0:
+            f_read += b'\0'
+        ds.EncapsulatedDocument = f_read
 
     ds.MIMETypeOfEncapsulatedDocument = 'application/pdf'
 

--- a/pdf2dicom.py
+++ b/pdf2dicom.py
@@ -29,6 +29,7 @@ def generate_dicom_from_pdf(pdf_file):
     with open(pdf_file, 'rb') as f:
         f_read = f.read()
         ValueLength = len(f_read)
+        ## All Dicom Element must have an even ValueLength
         if ValueLength % 2 != 0:
             f_read += b'\0'
         ds.EncapsulatedDocument = f_read


### PR DESCRIPTION
All DICOM elements should have an even Value Length. When storing documents may happen that these have an odd size, so it's necessary to pad them with a single byte to an even length before the DICOM encoding, otherwise, some problems can arise when storing in a DICOM server.