### PR TITLE
Refactor generate_random_uid

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,9 +1,7 @@
 import argparse
 import datetime
 from pdf2dicom import generate_dicom_from_pdf
-
-def generate_random_uid():
-    return '1.9.9.' + str(datetime.datetime.now().strftime('%H%M%S%f%d%m%Y'))
+from pydicom.uid import generate_uid
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -15,9 +13,9 @@ if __name__ == '__main__':
     e_pdf_ds.PatientName = 'John Doe'
     e_pdf_ds.PatientID = '12345'
     e_pdf_ds.PatientSex = 'M'
-    e_pdf_ds.StudyInstanceUID = generate_random_uid()
+    e_pdf_ds.StudyInstanceUID = generate_uid()
 
-    e_pdf_ds.SeriesInstanceUID = generate_random_uid()
-    e_pdf_ds.SOPInstanceUID = generate_random_uid() 
+    e_pdf_ds.SeriesInstanceUID = generate_uid()
+    e_pdf_ds.SOPInstanceUID = generate_uid() 
 
     e_pdf_ds.save_as('converted_dicom.dcm')


### PR DESCRIPTION
Addressing #5 
Use of `generate_uid` built-in function in pydicom module instead of
`generate_random_uid` custom function. 

With this  change StudyInstanceUID, SeriesInstanceUID, SOPInstanceUID will have all different IDs. In the previous code, these three IDs were all equal, since they were generated at the same hour, minutes and second, etc.

I think that having different IDs for these attributes is better but maybe it's right to have them equal like before. In this case, it's possible to specify a seed (the `entropy_srcs` [here](https://pydicom.github.io/pydicom/dev/reference/generated/pydicom.uid.generate_uid.html)) to obtain the same result.

Let me know what you think.